### PR TITLE
Change notifier message display formatting for linux desktop

### DIFF
--- a/platform/notifier.go
+++ b/platform/notifier.go
@@ -34,7 +34,7 @@ type DarwinNotifier struct {
 // Notify notifies desktop notifications on macOS
 func (d DarwinNotifier) Notify(output, dir string) {
 	pass, fail := parser.ParseOutput(output)
-	status := fmt.Sprintf("%d success %d fail", pass, fail)
+	status := fmt.Sprintf("%d pass, %d fail", pass, fail)
 	subtitle := filepath.Base(dir)
 	msg := fmt.Sprintf(
 		"display notification \"%s\" with title \"%s\" subtitle \"%s\"", status, "Snitch", subtitle)
@@ -48,8 +48,8 @@ type LinuxNotifier struct {
 // Notify notifies desktop notifications on Linux
 func (l LinuxNotifier) Notify(output, dir string) {
 	pass, fail := parser.ParseOutput(output)
-	status := fmt.Sprintf("%d success %d fail", pass, fail)
-	msg := fmt.Sprintf("'%s %s'", dir, status)
+	status := fmt.Sprintf("%d pass, %d fail", pass, fail)
+	msg := fmt.Sprintf("%s: %s", filepath.Base(dir), status)
 	err := exec.Command(
 		"notify-send", "-a", "Snitch", "-c", "im", "Snitch", msg).Run()
 	if err != nil {


### PR DESCRIPTION
# Description

This PR changes the notification message formatting on Linux for better display.
Also its change macOS notifcation message format for standardizing.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Start `$ snitch`
2. Save a test file in the project
3. Expect a notification to be shown with the new formatting

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
