### PR TITLE
Colorize test output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/axcdnt/snitch
 
 go 1.12
+
+require (
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/parser/result.go
+++ b/parser/result.go
@@ -5,9 +5,8 @@ import (
 )
 
 // ParseResult returns test statuses for pass and fail
-func ParseResult(output string) (pass, fail int) {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
+func ParseResult(result string) (pass, fail int) {
+	for _, line := range strings.Split(result, "\n") {
 		trimmed := strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(trimmed, "--- PASS"):

--- a/parser/result_test.go
+++ b/parser/result_test.go
@@ -20,16 +20,6 @@ func TestParseResult(t *testing.T) {
 			name: "it counts pass and fail",
 			args: args{
 				output: `
-				=== RUN   TestHello
-				=== RUN   TestHello/it_must_print_'hello,_person!'
-				=== RUN   TestHello/it_returns_'hello,_world!'_on_empty_string
-				=== RUN   TestHello/in_Spanish
-				=== RUN   TestHello/in_French
-				--- PASS: TestHello (0.00s)
-					--- PASS: TestHello/it_must_print_'hello,_person!' (0.00s)
-					--- PASS: TestHello/it_returns_'hello,_world!'_on_empty_string (0.00s)
-					--- PASS: TestHello/in_Spanish (0.00s)
-					--- PASS: TestHello/in_French (0.00s)
 				=== RUN   TestSum
 				=== RUN   TestSum/it_sums_collections_of_any_size
 				--- PASS: TestSum (0.00s)
@@ -46,7 +36,7 @@ func TestParseResult(t *testing.T) {
 				`,
 			},
 			want: status{
-				pass: 10,
+				pass: 5,
 				fail: 1,
 			},
 		},


### PR DESCRIPTION
# Description

This PR adds a new feature that colorizes test outputs. For success, it prints green, for failures, it prints red. It uses [color](https://github.com/fatih/color) to accomplish this.
By now, it has some kind of duplication on `prettyPrint(...)` and `parser.ParseResult(...)`, but I prefer to leave with it and abstract later since it has no performance implications.

Fixes #10 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run `snitch` and it must print a colorized stdout.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
